### PR TITLE
Recommend Time::Local 1.20 to solve RT #83803

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
     META_MERGE => {
         recommends => {
             'Time::Zone' => 0,
+            'Time::Local' => '1.2000',
         },
 	resources => {
             repository => 'http://github.com/gisle/http-date',


### PR DESCRIPTION
This patch adds Time::Local version 1.2 to the list of recommended distributions to address the issue raised in [RT #83803](https://rt.cpan.org/Public/Bug/Display.html?id=83803).

Version 1.2 of Time::Local adds support for older versions of Perl that cannot store epochs for dates far in the future.

This pull request is part of the CPAN PRC.
